### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ type fieldConfig = {
   // The chosen strategy. See "validation strategies" paragraph
   strategy: Strategy;
 
-  // Used to perform initial and current value comparaison
+  // Used to perform initial and current value comparison
   isEqual: (value1: Value, value2: Value) => boolean;
 
   // Will be run on value before validation and submission. Useful from trimming whitespaces


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'fullfil'. Here is your error report:
 https://triplechecker.com/s/UrFJcB/swan.io

Hope it's helpful!
